### PR TITLE
Lab 2 - Téo Dumoutier

### DIFF
--- a/exercice.jl
+++ b/exercice.jl
@@ -5,9 +5,20 @@ using LinearAlgebra
 #    Votre fonction ne doit modifier ni R ni b.
 function backsolve(R::UpperTriangular, b)
     x = similar(b)
-    ### votre code ici ; ne rien modifier d'autre
-    # ...
-    ###
+
+    n = size(R, 1)
+    for i in n:-1:1
+        c_i = b[i]
+
+        if i < n
+            for j in i+1:n
+                c_i -= R[i, j]*x[j]
+            end
+        end
+
+        x[i] = c_i / R[i, i]
+    end
+
     return x
 end
 
@@ -20,10 +31,49 @@ end
 #    fonction ne doit pas les renvoyer.
 #    Seul le cas réel sera testé ; pas le cas complexe.
 function hessenberg_solve(H::UpperHessenberg, b)
-    ### votre code ici ; ne rien modifier d'autre
-    # ...
-    # x = ...
-    ###
+    # Transformation de la matrice de Hessenberg à une matrice triangulaire supérieure
+    R = copy(H)
+    m, n = size(H)
+
+    # Rotations de Givens
+    for i in 1:n-1
+        Q_i_j = Matrix{Float64}(I, m, m)
+        j = i+1
+
+        x, y = R[i, i], R[j, i]
+        rho = norm([x, y])
+
+        c, s = x/rho, y/rho
+
+        Q_i_j[i, i] = c
+        Q_i_j[j, j] = c
+        Q_i_j[i, j] = s
+        Q_i_j[j, i] = -s
+
+        R = Q_i_j * R
+        b = Q_i_j * b
+    end
+    
+    # Réflexions de Givens
+    if m > n
+        e1 = zeros(m-n+1)
+        e1[1] = 1
+        v = copy(R[n:m, n])
+        
+        u = v - sign(v[1])*norm(v)*e1
+        u_ = u/(u'*u)
+        for j in 1:n
+            R[n:m, j] .-= 2*u_*(u'*R[n:m, j])
+        end
+        b[n:m] .-= 2*u_*(u'*b[n:m])
+
+    end
+
+    # Remontée triangulaire
+    R_thin = UpperTriangular(R[1:n, :])
+    b_thin = b[1:n]
+    x = backsolve(R_thin, b_thin)
+
     return x
 end
 
@@ -43,6 +93,7 @@ for n ∈ (10, 20, 30)
     # slightly overdetermined least squares
     A = rand(n + 1, n)
     A[diagind(A)] .+= 1
+    b = rand(n+1)
     H = UpperHessenberg(A)
     x_ls = hessenberg_solve(copy(H), copy(b))
     x_qr = H \ b


### PR DESCRIPTION
# Logique d'implémentation
## Backsolve
1. On considère R carré, triangulaire supérieur et de taille n x n, et un vecteur colonne b de taille n
2. Balaye les lignes de R de la dernière à la première (ligne i allant de n à 1)
3. Pour chacune, soustrait à b les coefficients de R à droite de la diagonale multipliés par les valeurs $x_j$ correspondantes
4. On note que cesdits $x_j$ seront toujours connus à droite de la diagonale étant donné un tel balayage
5. Divise le résultat par le coefficient de R sur la diagonale, ce qui donne le $x_i$ escompté
6. En résumé, on effectue l'opération mathématique suivante pour chaque ligne i de n à 1 :
 $$x_i = \frac{1}{R_{ii}} \left(b_i - \sum_{j = i+1}^n (R_{ij}* x_j)\right)$$

## Hessenberg_solve
1. On considère H de Hessenberg, de taille m x n, où m > n, et un vecteur colonne b de taille n+1
2. Balaye chaque colonne de H de la première à l'avant-dernière, et met l'élément juste en dessous de la diagonale à 0 grâce à une rotation de Givens
- Pour une composante cible $R_{ji}$, la matrice de rotation est l'identité dans laquelle on remplace : 
$c$ en (i, i), $c$ en (j, j), $s$ en (i, j) et $-s$ en (j, i)
où $c = R_{ii}/\rho$ et $s = R_{ji}/\rho$
$\rho = \sqrt{R_{ii}^2 + R_{ji}^2}$

3. Pour la dernière colonne, met tous les éléments en dessous de la diagonale à 0 grâce à une réflexion de Givens
- Pour la partie de l'avant-dernière colonne $v$ se situant sur et sous la diagonale, la matrice de Householder est :
$$H = I - 2\frac{uu^*}{u^*u}$$
où $u = v - sign(v[1])\lVert v \lVert e_1$
- Pour éviter l'encombrement mémoire, la matrice de réflexion et la matrice de Householder ne sont jamais formées, et seule l'action sur le bloc de H et de b se situant sur et sous la diagonale est calculée
4. Ensuite, avec la partie triangulaire supérieure (qui est R) et les éléments de b qui lui correspondent, appelle backsolve pour trouver $x$ : la solution du problème aux moindres carrés

# Notes
Il y avait une petite erreur de compatibilité entre les dimensions de la matrice H et et du vecteur b pour le test avec une matrice de Hessenberg surdéterminée. Je l'ai donc corrigée en redéfinissant un b aléatoire de taille n + 1.