### PR TITLE
Modification des deux fonctions du labo 2

### DIFF
--- a/exercice.jl
+++ b/exercice.jl
@@ -6,7 +6,11 @@ using LinearAlgebra
 function backsolve(R::UpperTriangular, b)
     x = similar(b)
     ### votre code ici ; ne rien modifier d'autre
-    # ...
+    n = length(b)
+    x[n] = b[n] / R[n,n]
+    for i in n-1:-1:1
+        x[i] = (b[i] - sum(R[i,j]*x[j] for j in i+1:n; init=zero(eltype(b)))) / R[i,i]
+    end
     ###
     return x
 end
@@ -21,8 +25,25 @@ end
 #    Seul le cas réel sera testé ; pas le cas complexe.
 function hessenberg_solve(H::UpperHessenberg, b)
     ### votre code ici ; ne rien modifier d'autre
-    # ...
-    # x = ...
+    m, n = size(H)
+
+    for i in 1:m-1
+        h₁, h₂ = H[i,i], H[i+1,i]
+        ρ = √(h₁^2+h₂^2)
+        c, s = h₁/ρ, h₂/ρ
+
+        for j in i:n
+            Hij, Hip1j = H[i,j], H[i+1,j]
+            H[i,j] = c*Hij + s*Hip1j
+            H[i+1,j] = c*Hip1j - s*Hij
+        end
+
+        bi, bip1 = b[i], b[i+1]
+        b[i] = c*bi + s*bip1
+        b[i+1] = c*bip1 - s*bi
+    end
+
+    x = backsolve(UpperTriangular(H[1:n,:]),b[1:n])
     ###
     return x
 end
@@ -44,6 +65,7 @@ for n ∈ (10, 20, 30)
     A = rand(n + 1, n)
     A[diagind(A)] .+= 1
     H = UpperHessenberg(A)
+    b = rand(n + 1)
     x_ls = hessenberg_solve(copy(H), copy(b))
     x_qr = H \ b
     @test norm(x_ls - x_qr) ≤ sqrt(eps()) * norm(x_qr)


### PR DESCRIPTION
## Fonction backsolve
J'ai fait une résolution simple en utilisant la remontée triangulaire. Je calcule le premier $x$ hors loop pour éviter une mauvaise indexation. 
## Fonction hessenberg_solve
On parcours la matrice H ligne par ligne jusqu'à l'avant dernière; on considère les vecteurs $2\times 2$ à modifier à partir de la première composante, on parcours donc jusqu'à la $m-1$ ligne. Pour chaque ligne, on calcule d'abord les paramètres de la rotation de Givens, puis ensuite on parcoure les 2 lignes modifiées par la rotation ($i$ et $i+1$) et on l'applique. On applique finalement la rotation au vecteur $b$.
Pour pouvoir utiliser backsolve, on transforme la matrice $H$ modifiée en triangulaire supérieure en considérant les lignes 1 à $n$ (ce qui permet de prendre en compte le cas surdéterminé). On prend les composantes 1 à $n$ du vecteur $b$. 
La fonction retourne $x$ seulement, mais $H$ et $b$ sont modifiées par ma fonction. 