### PR TITLE
Ajout dans exercice.jl

### DIFF
--- a/exercice.jl
+++ b/exercice.jl
@@ -5,9 +5,14 @@ using LinearAlgebra
 #    Votre fonction ne doit modifier ni R ni b.
 function backsolve(R::UpperTriangular, b)
     x = similar(b)
-    ### votre code ici ; ne rien modifier d'autre
-    # ...
-    ###
+    n = length(b)                     
+    for i in n:-1:1                    
+        s = zero(eltype(b))            
+        for j in i+1:n                 
+            s += R[i,j] * x[j]         
+        end
+        x[i] = (b[i] - s) / R[i,i]     
+    end
     return x
 end
 
@@ -20,32 +25,54 @@ end
 #    fonction ne doit pas les renvoyer.
 #    Seul le cas réel sera testé ; pas le cas complexe.
 function hessenberg_solve(H::UpperHessenberg, b)
-    ### votre code ici ; ne rien modifier d'autre
-    # ...
-    # x = ...
-    ###
+    m, n = size(H)
+    for j = 1:n
+        if j < m
+            e1, e2 = H[j, j], H[j+1, j]
+            r = sqrt(e1^2 + e2^2) # norme euclidienne
+            if r != 0
+                c = e1 / r
+                s = -e2 / r
+                # Applique la rotation à H
+                for k = j:n
+                    e1, e2 = H[j, k], H[j+1, k]
+                    H[j, k]     =  c * e1 - s * e2
+                    H[j+1, k]   =  s * e1 + c * e2
+                end
+                # Applique la rotation à b
+                e1, e2 = b[j], b[j+1]
+                b[j]   =  c * e1 - s * e2
+                b[j+1] =  s * e1 + c * e2
+            end
+        end
+    end
+    # Après les rotations, les n premières lignes de H forment une matrice triangulaire supérieure
+    R = UpperTriangular(H[1:n, 1:n])
+    x = backsolve(R, b[1:n])
     return x
 end
 
 # vérification
 using Test
-for n ∈ (10, 20, 30)
-    # square system
-    A = rand(n, n)
-    A[diagind(A)] .+= 1
-    b = rand(n)
-    R = UpperTriangular(A)
-    x = backsolve(R, b)
-    @test norm(R * x - b) ≤ sqrt(eps()) * norm(b)
-    H = UpperHessenberg(A)
-    x = hessenberg_solve(copy(H), copy(b))
-    @test norm(H * x - b) ≤ sqrt(eps()) * norm(b)
-    # slightly overdetermined least squares
-    A = rand(n + 1, n)
-    A[diagind(A)] .+= 1
-    H = UpperHessenberg(A)
-    b = rand(n + 1)
-    x_ls = hessenberg_solve(copy(H), copy(b))
-    x_qr = H \ b
-    @test norm(x_ls - x_qr) ≤ sqrt(eps()) * norm(x_qr)
+@testset "Tests systèmes triangulaires et Hessenberg" begin
+    for n ∈ (10, 20, 30)
+        # square system
+        A = rand(n, n)
+        A[diagind(A)] .+= 1
+        b = rand(n)
+        R = UpperTriangular(A)
+        x = backsolve(R, b)
+        @test norm(R * x - b) ≤ sqrt(eps()) * norm(b)
+        H = UpperHessenberg(A)
+        x = hessenberg_solve(copy(H), copy(b))
+        @test norm(H * x - b) ≤ sqrt(eps()) * norm(b)
+        # slightly overdetermined least squares
+        A = rand(n + 1, n)
+        A[diagind(A)] .+= 1
+        H = UpperHessenberg(A)
+        b = rand(n + 1)
+        x_ls = hessenberg_solve(copy(H), copy(b))
+        x_qr = H \ b
+        @test norm(x_ls - x_qr) ≤ sqrt(eps()) * norm(x_qr)
+    end
 end


### PR DESCRIPTION
## Explications et description de l’implémentation

### Fonction `backsolve`

La fonction `backsolve` résout un système linéaire triangulaire supérieur $R x = b$ en utilisant la **remontée triangulaire** . Cela signifie qu’on commence par la dernière inconnue, puis on remonte progressivement vers la première. On initialise une variable s à zéro. Cette variable stocke la somme des produits connus à droite de la diagonale, c’est-à-dire les valeurs déjà calculées multipliées par les éléments correspondants dans la ligne actuelle. Par la suite, on isole l’inconnue $x_i$. La remonté complète permet donc de résoudre le système.
​
 
### Fonction `hessenberg_solve`

La fonction `hessenberg_solve` résout le système $H x = b$, où $H$ est une **matrice de Hessenberg supérieure**  ou le problème aux moindres carrés $\min_x \|H x - b\|$ si $H$ est rectangulaire ($m = n+1$).

- On ,utilise les **rotations de Givens** pour transformer $H$ en une matrice triangulaire supérieure $R$.
    - À chaque colonne $j$, on annule $H_{j+1, j}$ en appliquant une rotation de Givens sur les lignes $j$ et $j+1$.
    - La même rotation est appliquée à $b$ pour préserver l’équivalence du système.
- Une fois $H$ transformée, on extrait la partie triangulaire supérieure $R$ et on résout $R x = c$ par `backsolve`.
    - Dans le cas surdéterminé (une ligne de plus que de colonnes), cela correspond à la **solution aux moindres carrés** et on prend seulement les n premières lignes de H forment une matrice triangulaire supérieure.
#### Formules utilisées pour la rotation de Givens :

Pour annuler $e_2$ sous $e_1$ :
- $r = \sqrt{e_1^2 + e_2^2}$
- $c = e_1/r$
- $s = -e_2/r$

---
### Modification de la section `Test`

Étant donné que Test passed ne s'affichait pas pour aucun des test, un Testset a été ajouté afin de confirmer que tous les tests ont passé: 
```julia
@testset "Tests systèmes triangulaires et Hessenberg" begin
# Code du test original
end
```
Cet ajout n'est pas nécessaire, car lorsqu'un test n'était pas validé, un message Test failed était présenté (ce qui implique qu'aucun message signifie que les test sont validés). Cet ajout permet seulement d'avoir un visuel lorsque tous les test sont validés!